### PR TITLE
add options for jasmine spec runners

### DIFF
--- a/src/jasmine/jasmine.js
+++ b/src/jasmine/jasmine.js
@@ -38,15 +38,16 @@ const Jasmine = {
   tasks: {
     jasmine() {
       const plugin = new (require('gulp-jasmine-browser/webpack/jasmine-plugin'))();
-      return Jasmine.appAssets({plugins: [plugin]})
-        .pipe(jasmineBrowser.specRunner())
-        .pipe(jasmineBrowser.server({whenReady: plugin.whenReady}));
+      const {browserAppAssetsOptions, browserServerOptions, browserSpecRunnerOptions} = Jasmine.installOptions;
+      return Jasmine.appAssets({plugins: [plugin], browserAppAssetsOptions})
+        .pipe(jasmineBrowser.specRunner(browserSpecRunnerOptions))
+        .pipe(jasmineBrowser.server({whenReady: plugin.whenReady, ...browserServerOptions}));
     },
     specApp() {
-      const {headlessConfig} = Jasmine.installOptions;
-      return Jasmine.appAssets({watch: false})
-        .pipe(jasmineBrowser.specRunner({console: true}))
-        .pipe(jasmineBrowser.headless({driver: 'phantomjs', ...headlessConfig}));
+      const {headlessAppAssetsOptions, headlessServerOptions, headlessSpecRunnerOptions} = Jasmine.installOptions;
+      return Jasmine.appAssets({watch: false, ...headlessAppAssetsOptions})
+        .pipe(jasmineBrowser.specRunner({console: true, ...headlessSpecRunnerOptions}))
+        .pipe(jasmineBrowser.headless({driver: 'phantomjs', ...headlessServerOptions}));
     },
     specServer(){
       const env = processEnv({NODE_ENV: 'test'});

--- a/src/webpack/development.js
+++ b/src/webpack/development.js
@@ -5,7 +5,7 @@ const {assetHost, assetPort} = require('../assets/config');
 const publicPath = assetHost ? `//${assetHost}:${assetPort}/` : '/';
 
 module.exports = {
-  devtool: 'source-map',
+  devtool: 'cheap-module-source-map',
   entry: {
     application: ['./app/components/application.js', `webpack-hot-middleware/client?path=${`${publicPath}__webpack_hmr`}`]
   },

--- a/src/webpack/production.js
+++ b/src/webpack/production.js
@@ -9,7 +9,7 @@ module.exports = {
         'NODE_ENV': '"production"'
       }
     }),
-    new UglifyJsPlugin({compress: {warnings: false}}),
+    new UglifyJsPlugin({compress: {warnings: false}, sourceMap: false}),
     noErrors,
     extractCss,
     extractSass


### PR DESCRIPTION
change the default configuration for development to use faster eval source map. production mode should not attempt to add source maps for the uglify plugin